### PR TITLE
Removed duplicate functions from device.hpp

### DIFF
--- a/examples/parameters/matrix.cpp
+++ b/examples/parameters/matrix.cpp
@@ -178,8 +178,8 @@ int main()
 
   std::string devname   = dev.name();
   std::string driver    = dev.driver_version();
-  cl_uint compunits = dev.max_compute_units();      
-  std::size_t  wgsize    = dev.max_workgroup_size();        
+  cl_uint compunits     = dev.max_compute_units();
+  std::size_t  wgsize   = dev.max_workgroup_size();
   
   // -----------------------------------------
    paras.add_device();
@@ -191,24 +191,24 @@ int main()
   
   //set up test config:
   test_config conf;
-  conf.max_local_size(dev.max_work_group_size());
+  conf.max_local_size(dev.max_workgroup_size());
   
   // GPU specific test setup:
   if (dev.type() == CL_DEVICE_TYPE_GPU)
   {
     unsigned int units = 1;
-    while (2 * units < dev.compute_units())
+    while (2 * units < dev.max_compute_units())
       units *= 2;
     conf.min_work_groups(units);
     conf.max_work_groups(512); //reasonable upper limit on current GPUs
     
     conf.min_local_size(16); //less than 16 threads per work group is unlikely to have any impact
-    //conf.min_local_size(dev.max_work_group_size()); //testing only
+    //conf.min_local_size(dev.max_workgroup_size()); //testing only
   } 
   else if (dev.type() == CL_DEVICE_TYPE_CPU)// CPU specific test setup
   {
     conf.min_work_groups(1);
-    conf.max_work_groups(2*dev.compute_units()); //reasonable upper limit on current CPUs - more experience needed here!
+    conf.max_work_groups(2*dev.max_compute_units()); //reasonable upper limit on current CPUs - more experience needed here!
     
     conf.min_local_size(1);
   }

--- a/examples/parameters/sparse.cpp
+++ b/examples/parameters/sparse.cpp
@@ -156,7 +156,7 @@ int main()
 
   std::string devname   = dev.name();
   std::string driver    = dev.driver_version();
-  cl_uint compunits = dev.max_compute_units();      
+  cl_uint compunits     = dev.max_compute_units();
   std::size_t wgsize    = dev.max_workgroup_size();        
   
   // -----------------------------------------
@@ -169,19 +169,19 @@ int main()
   
   //set up test config:
   test_config conf;
-  conf.max_local_size(dev.max_work_group_size());
+  conf.max_local_size(dev.max_workgroup_size());
   
   // GPU specific test setup:
   if (dev.type() == CL_DEVICE_TYPE_GPU)
   {
     unsigned int units = 1;
-    while (2 * units < dev.compute_units())
+    while (2 * units < dev.max_compute_units())
       units *= 2;
     conf.min_work_groups(units);
     conf.max_work_groups(512); //reasonable upper limit on current GPUs
     
     conf.min_local_size(16); //less than 16 threads per work group is unlikely to have any impact
-    //conf.min_local_size(dev.max_work_group_size()); //testing only
+    //conf.min_local_size(dev.max_workgroup_size()); //testing only
   } 
   else if (dev.type() == CL_DEVICE_TYPE_CPU)// CPU specific test setup
   {

--- a/examples/parameters/vector.cpp
+++ b/examples/parameters/vector.cpp
@@ -165,7 +165,7 @@ int main()
 
   std::string devname   = dev.name();
   std::string driver    = dev.driver_version();
-  cl_uint compunits = dev.max_compute_units();      
+  cl_uint compunits     = dev.max_compute_units();
   std::size_t wgsize    = dev.max_workgroup_size();        
   
   // -----------------------------------------
@@ -178,24 +178,24 @@ int main()
   
   //set up test config:
   test_config conf;
-  conf.max_local_size(dev.max_work_group_size());
+  conf.max_local_size(dev.max_workgroup_size());
   
   // GPU specific test setup:
   if (dev.type() == CL_DEVICE_TYPE_GPU)
   {
     unsigned int units = 1;
-    while (2 * units < dev.compute_units())
+    while (2 * units < dev.max_compute_units())
       units *= 2;
     conf.min_work_groups(units);
     conf.max_work_groups(512); //reasonable upper limit on current GPUs
     
     conf.min_local_size(16); //less than 16 threads per work group is unlikely to have any impact
-    //conf.min_local_size(dev.max_work_group_size()); //testing only
+    //conf.min_local_size(dev.max_workgroup_size()); //testing only
   } 
   else if (dev.type() == CL_DEVICE_TYPE_CPU)// CPU specific test setup
   {
     conf.min_work_groups(1);
-    conf.max_work_groups(2*dev.compute_units()); //reasonable upper limit on current CPUs - more experience needed here!
+    conf.max_work_groups(2*dev.max_compute_units()); //reasonable upper limit on current CPUs - more experience needed here!
     
     conf.min_local_size(1);
   }

--- a/viennacl/ocl/device.hpp
+++ b/viennacl/ocl/device.hpp
@@ -240,8 +240,6 @@ namespace viennacl
           return ret;
         }
         
-        std::size_t max_work_group_size() const { return max_work_group_size_; }
-        cl_uint compute_units() const { return compute_units_; }
         cl_device_type type() const { return type_; }
         
         bool operator==(device const & other) const


### PR DESCRIPTION
Hi,

I have removed instances of the duplicate functions from the existing code and did a build check. Some of the newer projects weren't compiling with visual studio, but the errors were for different reasons (most were "typename cannot be used outside a template declaration"), so I rechecked them manually. Please let me know if it breaks something.
