### PR TITLE
a few Apple-OpenCL-include fixes

### DIFF
--- a/viennacl/generator/helpers.hpp
+++ b/viennacl/generator/helpers.hpp
@@ -25,7 +25,11 @@
 
 #include <set>
 
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
 #include "CL/cl.h"
+#endif
 
 #include "viennacl/forwards.h"
 #include "viennacl/scheduler/forwards.h"

--- a/viennacl/meta/predicate.hpp
+++ b/viennacl/meta/predicate.hpp
@@ -28,7 +28,11 @@
 #include "viennacl/forwards.h"
 
 #ifdef VIENNACL_WITH_OPENCL
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
 #include "CL/cl.h"
+#endif
 #endif
 
 namespace viennacl

--- a/viennacl/meta/result_of.hpp
+++ b/viennacl/meta/result_of.hpp
@@ -43,7 +43,11 @@
 #endif
 
 #ifdef VIENNACL_WITH_OPENCL
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
 #include "CL/cl.h"
+#endif
 #endif
 
 #include <vector>


### PR DESCRIPTION
I needed these 3 fixes to make [my small example](https://github.com/albertz/playground/blob/master/viennacl_test.cpp) work under MacOSX.
