### PR TITLE
Fix OpenMP compile error when OpenMP 2.5 for Microsoft Visual Studio

### DIFF
--- a/viennacl/forwards.h
+++ b/viennacl/forwards.h
@@ -55,6 +55,15 @@ namespace viennacl
 {
   typedef std::size_t                                       vcl_size_t;
   typedef std::ptrdiff_t                                    vcl_ptrdiff_t;
+#ifdef _MSC_VER
+#ifdef  _WIN64
+  typedef __int64  omp_index;
+#else
+  typedef _W64 int omp_index;
+#endif
+#else
+  typedef std::size_t omp_index;
+#endif
 
 
   /** @brief A tag class representing assignment */

--- a/viennacl/linalg/host_based/sparse_matrix_operations.hpp
+++ b/viennacl/linalg/host_based/sparse_matrix_operations.hpp
@@ -118,7 +118,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-        for (std::size_t row = 0; row < mat.size1(); ++row)
+        for (omp_index row = 0; row < static_cast<omp_index>(mat.size1()); ++row)
         {
           ScalarType dot_prod = 0;
           std::size_t row_end = row_buffer[row+1];
@@ -172,7 +172,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t row = 0; row < sp_mat.size1(); ++row) {
+          for (omp_index row = 0; row < static_cast<omp_index>(sp_mat.size1()); ++row) {
             std::size_t row_start = sp_mat_row_buffer[row];
             std::size_t row_end = sp_mat_row_buffer[row+1];
             for (std::size_t col = 0; col < d_mat.size2(); ++col) {
@@ -188,7 +188,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t col = 0; col < d_mat.size2(); ++col) {
+          for (omp_index col = 0; col < static_cast<omp_index>(d_mat.size2()); ++col) {
             for (std::size_t row = 0; row < sp_mat.size1(); ++row) {
               std::size_t row_start = sp_mat_row_buffer[row];
               std::size_t row_end = sp_mat_row_buffer[row+1];
@@ -249,7 +249,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t row = 0; row < sp_mat.size1(); ++row) {
+          for (omp_index row = 0; row < static_cast<omp_index>(sp_mat.size1()); ++row) {
             std::size_t row_start = sp_mat_row_buffer[row];
             std::size_t row_end = sp_mat_row_buffer[row+1];
             for (std::size_t col = 0; col < d_mat.size2(); ++col) {
@@ -265,7 +265,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t col = 0; col < d_mat.size2(); ++col) {
+          for (omp_index col = 0; col < static_cast<omp_index>(d_mat.size2()); ++col) {
             for (std::size_t row = 0; row < sp_mat.size1(); ++row) {
               std::size_t row_start = sp_mat_row_buffer[row];
               std::size_t row_end = sp_mat_row_buffer[row+1];
@@ -871,7 +871,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-        for (std::size_t i = 0; i < mat.nnz1(); ++i)
+        for (omp_index i = 0; i < static_cast<omp_index>(mat.nnz1()); ++i)
         {
           ScalarType dot_prod = 0;
           std::size_t row_end = row_buffer[i+1];
@@ -1016,14 +1016,14 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t row = 0; row < sp_mat.size1(); ++row)
+          for (omp_index row = 0; row < static_cast<omp_index>(sp_mat.size1()); ++row)
                 for (std::size_t col = 0; col < d_mat.size2(); ++col)
                   result_wrapper( row, col) = (NumericT)0; /* filling result with zeros, as the product loops are reordered */
 
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t i = 0; i < sp_mat.nnz(); ++i) {
+          for (omp_index i = 0; i < static_cast<omp_index>(sp_mat.nnz()); ++i) {
             NumericT x = static_cast<NumericT>(sp_mat_elements[i]);
             unsigned int r = sp_mat_coords[2*i];
             unsigned int c = sp_mat_coords[2*i+1];
@@ -1039,14 +1039,14 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t col = 0; col < d_mat.size2(); ++col)
+          for (omp_index col = 0; col < static_cast<omp_index>(d_mat.size2()); ++col)
             for (std::size_t row = 0; row < sp_mat.size1(); ++row)
                 result_wrapper( row, col) = (NumericT)0; /* filling result with zeros, as the product loops are reordered */
 
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t col = 0; col < d_mat.size2(); ++col) {
+          for (omp_index col = 0; col < static_cast<omp_index>(d_mat.size2()); ++col) {
 
             for (std::size_t i = 0; i < sp_mat.nnz(); ++i) {
 
@@ -1109,7 +1109,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t row = 0; row < sp_mat.size1(); ++row)
+          for (omp_index row = 0; row < static_cast<omp_index>(sp_mat.size1()); ++row)
             for (std::size_t col = 0; col < d_mat.size2(); ++col)
               result_wrapper( row, col) = (NumericT)0; /* filling result with zeros, as the product loops are reordered */
         }
@@ -1118,7 +1118,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t col = 0; col < d_mat.size2(); ++col)
+          for (omp_index col = 0; col < static_cast<omp_index>(d_mat.size2()); ++col)
             for (std::size_t row = 0; row < sp_mat.size1(); ++row)
               result_wrapper( row, col) = (NumericT)0; /* filling result with zeros, as the product loops are reordered */
         }
@@ -1126,7 +1126,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-        for (std::size_t i = 0; i < sp_mat.nnz(); ++i) {
+        for (omp_index i = 0; i < static_cast<omp_index>(sp_mat.nnz()); ++i) {
           NumericT x = static_cast<NumericT>(sp_mat_elements[i]);
           unsigned int r = sp_mat_coords[2*i];
           unsigned int c = sp_mat_coords[2*i+1];
@@ -1249,14 +1249,14 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t col = 0; col < d_mat.size2(); ++col)
+          for (omp_index col = 0; col < static_cast<omp_index>(d_mat.size2()); ++col)
             for(std::size_t row = 0; row < sp_mat.size1(); ++row)
                 result_wrapper( row, col) = (NumericT)0; /* filling result with zeros, as the product loops are reordered */
 
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t col = 0; col < d_mat.size2(); ++col) {
+          for (omp_index col = 0; col < static_cast<omp_index>(d_mat.size2()); ++col) {
 
             for(unsigned int item_id = 0; item_id < sp_mat.maxnnz(); ++item_id) {
 
@@ -1348,14 +1348,14 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for (std::size_t col = 0; col < d_mat.size2(); ++col)
+          for (omp_index col = 0; col < static_cast<omp_index>(d_mat.size2()); ++col)
             for(std::size_t row = 0; row < sp_mat.size1(); ++row)
                 result_wrapper( row, col) = (NumericT)0; /* filling result with zeros, as the product loops are reordered */
 
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for
 #endif
-          for(unsigned int item_id = 0; item_id < sp_mat.maxnnz(); ++item_id) {
+          for(omp_index item_id = 0; item_id < static_cast<omp_index>(sp_mat.maxnnz()); ++item_id) {
 
             for(std::size_t row = 0; row < sp_mat.size1(); ++row) {
 

--- a/viennacl/linalg/host_based/vector_operations.hpp
+++ b/viennacl/linalg/host_based/vector_operations.hpp
@@ -77,7 +77,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
           #pragma omp parallel for if (size1 > VIENNACL_OPENMP_VECTOR_MIN_SIZE)
 #endif
-          for (std::size_t i = 0; i < size1; ++i)
+          for (omp_index i = 0; i < static_cast<omp_index>(size1); ++i)
             data_vec1[i*inc1+start1] = data_vec2[i*inc2+start2] / data_alpha;
         }
         else
@@ -85,7 +85,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
           #pragma omp parallel for if (size1 > VIENNACL_OPENMP_VECTOR_MIN_SIZE)
 #endif
-          for (std::size_t i = 0; i < size1; ++i)
+          for (omp_index i = 0; i < static_cast<omp_index>(size1); ++i)
             data_vec1[i*inc1+start1] = data_vec2[i*inc2+start2] * data_alpha;
         }
       }
@@ -127,7 +127,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
             #pragma omp parallel for if (size1 > VIENNACL_OPENMP_VECTOR_MIN_SIZE)
 #endif
-            for (std::size_t i = 0; i < size1; ++i)
+            for (omp_index i = 0; i < static_cast<omp_index>(size1); ++i)
               data_vec1[i*inc1+start1] = data_vec2[i*inc2+start2] / data_alpha + data_vec3[i*inc3+start3] / data_beta;
           }
           else
@@ -135,7 +135,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
             #pragma omp parallel for if (size1 > VIENNACL_OPENMP_VECTOR_MIN_SIZE)
 #endif
-            for (std::size_t i = 0; i < size1; ++i)
+            for (omp_index i = 0; i < static_cast<omp_index>(size1); ++i)
               data_vec1[i*inc1+start1] = data_vec2[i*inc2+start2] / data_alpha + data_vec3[i*inc3+start3] * data_beta;
           }
         }
@@ -146,7 +146,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
             #pragma omp parallel for if (size1 > VIENNACL_OPENMP_VECTOR_MIN_SIZE)
 #endif
-            for (std::size_t i = 0; i < size1; ++i)
+            for (omp_index i = 0; i < static_cast<omp_index>(size1); ++i)
               data_vec1[i*inc1+start1] = data_vec2[i*inc2+start2] * data_alpha + data_vec3[i*inc3+start3] / data_beta;
           }
           else
@@ -154,7 +154,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
             #pragma omp parallel for if (size1 > VIENNACL_OPENMP_VECTOR_MIN_SIZE)
 #endif
-            for (std::size_t i = 0; i < size1; ++i)
+            for (omp_index i = 0; i < static_cast<omp_index>(size1); ++i)
               data_vec1[i*inc1+start1] = data_vec2[i*inc2+start2] * data_alpha + data_vec3[i*inc3+start3] * data_beta;
           }
         }
@@ -256,7 +256,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for if (loop_bound > VIENNACL_OPENMP_VECTOR_MIN_SIZE)
 #endif
-        for (std::size_t i = 0; i < loop_bound; ++i)
+        for (omp_index i = 0; i < static_cast<omp_index>(loop_bound); ++i)
           data_vec1[i*inc1+start1] = data_alpha;
       }
 
@@ -391,7 +391,7 @@ namespace viennacl
 #ifdef VIENNACL_WITH_OPENMP
         #pragma omp parallel for reduction(+: temp) if (size1 > VIENNACL_OPENMP_VECTOR_MIN_SIZE)
 #endif
-        for (std::size_t i = 0; i < size1; ++i)
+        for (omp_index i = 0; i < static_cast<omp_index>(size1); ++i)
           temp += data_vec1[i*inc1+start1] * data_vec2[i*inc2+start2];
 
         result = temp;  //Note: Assignment to result might be expensive, thus 'temp' is used for accumulation


### PR DESCRIPTION
C3016 error [1] occurs when compiling ViennaCL with Microsoft Visual Studio.

This is because MSVS supports OpenMP _2.0_ [2]  and unsigned index are not allowed for loop index in OpenMP 2.0 [3].

Same problem is not MSVS's problem.
This problem should be occurs when
- the compiler support less than OpenMP 3.0
- and std::size_t is defined as unsigned.

My pull-request is an example to show how to fix this, doesn't fix all problem but only some cases on MSVS.

Or does ViennaCL support only OpenMP 3.0 or later?
- [1] http://msdn.microsoft.com/library/vstudio/ee306688.aspx
- [2] http://msdn.microsoft.com/library/fw509c3b.aspx
- [3] http://stackoverflow.com/questions/2820621
