### PR TITLE
Changed hash[5] type from u_int32_t to uint32_t

### DIFF
--- a/viennacl/tools/sha1.hpp
+++ b/viennacl/tools/sha1.hpp
@@ -206,7 +206,7 @@ namespace viennacl
       detail::sha1 sha1;
       sha1.processBytes(src.c_str(),src.size());
 
-      u_int32_t hash[5];
+      uint32_t hash[5];
       sha1.getDigest(hash);
 
       std::ostringstream oss;


### PR DESCRIPTION
Using uint32_t will make this part of code useable in a Windows
environment as it is a part of C99 standard and available with VS2010,
whereas u_int32_t is not available on Windows platorms.
