### PR TITLE
Fix a bug in hyb_matrix constructor

### DIFF
--- a/viennacl/hyb_matrix.hpp
+++ b/viennacl/hyb_matrix.hpp
@@ -118,7 +118,7 @@ namespace viennacl
       {
         //determine max capacity for row
         vcl_size_t max_entries_per_row = 0;
-        std::vector<vcl_size_t> hist_entries(cpu_matrix.size1() + 1, 0);
+        std::vector<vcl_size_t> hist_entries(cpu_matrix.size2() + 1, 0);
 
         for (typename CPU_MATRIX::const_iterator1 row_it = cpu_matrix.begin1(); row_it != cpu_matrix.end1(); ++row_it)
         {


### PR DESCRIPTION
The bug lead to array overrun for non-square matrices where number of rows was less than number of columns.

The hist_entries vector should contain enough elements to hold full row of a matrix, not a full column.

P.S. I think this is second time I am fixing the same bug, sorry for not doing it right the first time :).
