### PR TITLE
Change assert to exception in get_queue

### DIFF
--- a/viennacl/ocl/context.hpp
+++ b/viennacl/ocl/context.hpp
@@ -275,7 +275,9 @@ namespace viennacl
         /** @brief Returns the queue with the provided index for the given device */
         viennacl::ocl::command_queue & get_queue(cl_device_id dev, vcl_size_t i = 0)
         {
-          assert(i < queues_.size() && bool("In class 'context': id invalid in get_queue()"));
+          if(i >= queues_[dev].size())
+            throw invalid_command_queue();
+
           #if defined(VIENNACL_DEBUG_ALL) || defined(VIENNACL_DEBUG_CONTEXT)
           std::cout << "ViennaCL: Getting queue " << i << " for device " << dev << " in context " << h_ << std::endl;
           #endif


### PR DESCRIPTION
It would be useful for PyViennaCL for this assert to be an exception instead. I've hijacked the invalid_command_queue exception (which seems appropriate, if not technically correct), but anything would probably do. The problem with assert is that it causes Python to die.

I had a look at systematically changing all the asserts in ViennaCL to exceptions, but as there are more than 500 of them, that's probably a project for another day..
