### PR TITLE
Update timer.hpp to fix declaration bug

### DIFF
--- a/viennacl/tools/timer.hpp
+++ b/viennacl/tools/timer.hpp
@@ -66,7 +66,7 @@ namespace viennacl{
     private:
       LARGE_INTEGER freq;
       LARGE_INTEGER start_time;
-	  LARGE_INTERGET end_time;
+      LARGE_INTEGER end_time;
     };
 
   }


### PR DESCRIPTION
It looks like end_time was not properly defined and thus caused a compilation error.
