### PR TITLE
Removing dead code.

### DIFF
--- a/viennacl/compressed_matrix.hpp
+++ b/viennacl/compressed_matrix.hpp
@@ -33,6 +33,10 @@
 #include "viennacl/tools/tools.hpp"
 #include "viennacl/tools/entry_proxy.hpp"
 
+#ifdef VIENNACL_WITH_UBLAS
+#include <boost/numeric/ublas/matrix_sparse.hpp>
+#endif
+
 namespace viennacl
 {
 namespace detail


### PR DESCRIPTION
`row_entries` is never used inside this function, but I doubt the compiler can optimize it out by himself, because `memory_read` calls external functions that may have side effects.
