### PR TITLE
Move direct_solve to ublas executables.

### DIFF
--- a/examples/benchmarks/CMakeLists.txt
+++ b/examples/benchmarks/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Targets using CPU-based execution
-foreach(bench dense_blas scheduler direct_solve)
+foreach(bench dense_blas scheduler)
    add_executable(${bench}-bench-cpu ${bench}.cpp)
 endforeach()
 
 if (ENABLE_UBLAS)
     include_directories(${Boost_INCLUDE_DIRS})
-    foreach(bench sparse solver)
+    foreach(bench sparse solver direct_solve)
       add_executable(${bench}-bench-cpu ${bench}.cpp)
       target_link_libraries(${bench}-bench-cpu ${Boost_LIBRARIES})
     endforeach()
@@ -15,7 +15,7 @@ endif (ENABLE_UBLAS)
 # Targets using OpenCL
 if (ENABLE_OPENCL)
 
-  foreach(bench dense_blas opencl direct_solve)
+  foreach(bench dense_blas opencl)
     add_executable(${bench}-bench-opencl ${bench}.cpp)
     target_link_libraries(${bench}-bench-opencl ${OPENCL_LIBRARIES})
     set_target_properties(${bench}-bench-opencl PROPERTIES COMPILE_FLAGS "-DVIENNACL_WITH_OPENCL")
@@ -23,7 +23,7 @@ if (ENABLE_OPENCL)
 
   if (ENABLE_UBLAS)
      include_directories(${Boost_INCLUDE_DIRS})
-     foreach(bench sparse solver)
+     foreach(bench sparse solver direct_solve)
        add_executable(${bench}-bench-opencl ${bench}.cpp)
        target_link_libraries(${bench}-bench-opencl ${OPENCL_LIBRARIES} ${Boost_LIBRARIES})
        set_target_properties(${bench}-bench-opencl PROPERTIES COMPILE_FLAGS "-DVIENNACL_WITH_OPENCL")


### PR DESCRIPTION
When configuring as follows

```
/scr_ivy2/dmeiser/PTSOLVE/cmake/bin/cmake \
  -DCMAKE_INSTALL_PREFIX:PATH=/scr_ivy2/dmeiser/PTSOLVE/viennacl-master.r988-ser \
  -DCMAKE_BUILD_TYPE:STRING=Release \
  -DCMAKE_COLOR_MAKEFILE:BOOL=FALSE \
  -DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
  -DCMAKE_C_COMPILER:FILEPATH='/usr/bin/gcc' \
  -DCMAKE_CXX_COMPILER:FILEPATH='/usr/bin/g++' \
  -DCMAKE_Fortran_COMPILER:FILEPATH='/usr/bin/gfortran' \
  -DCMAKE_C_FLAGS:STRING='-pipe -fPIC' \
  -DCMAKE_CXX_FLAGS:STRING='-pipe -fPIC' \
  -DCMAKE_Fortran_FLAGS:STRING='-fPIC' \
  -DSUPRA_SEARCH_PATH:PATH='/scr_ivy2/dmeiser/PTSOLVE;/scr_ivy2/dmeiser/PTSOLVE/userdocs' \
  -DBOOST_ROOT:PATH=/scr_ivy2/dmeiser/PTSOLVE/boost \
  -DBoost_NO_BOOST_CMAKE:BOOL=ON \
  -DOPENCL_INCLUDE_DIR:PATH=/usr/local/cuda/include \
  -DOPENCL_LIBRARY:FILEPATH=/usr/local/cuda/lib64/libOpenCL.so \
  /scr_ivy/dmeiser/ptsolveall/viennacl
```

I encounter compiler errors with `examples/benchmarks/direct_solve.cpp`:

```
cd /scr_ivy/dmeiser/ptsolveall/builds/viennacl/ser/examples/benchmarks && /usr/bin/g++    -pipe -fPIC -O3 -DNDEBUG -I/scr_ivy/dmeiser/ptsolveall/viennacl -I/usr/local/cuda/include    -o CMakeFiles/direct_solve-bench-cpu.dir/direct_solve.cpp.o -c /scr_ivy/dmeiser/ptsolveall/viennacl/examples/benchmarks/direct_solve.cpp
In file included from /scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/scalar.hpp:29,
                 from /scr_ivy/dmeiser/ptsolveall/viennacl/examples/benchmarks/direct_solve.cpp:27:
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/result_of.hpp:32:49: error: boost/numeric/ublas/matrix_sparse.hpp: No such file or directory
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/result_of.hpp:33:42: error: boost/numeric/ublas/matrix.hpp: No such file or directory
In file included from /scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/linalg/prod.hpp:30,
                 from /scr_ivy/dmeiser/ptsolveall/viennacl/examples/benchmarks/direct_solve.cpp:31:
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/tag_of.hpp:34:42: error: boost/numeric/ublas/vector.hpp: No such file or directory
In file included from /scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/scalar.hpp:29,
                 from /scr_ivy/dmeiser/ptsolveall/viennacl/examples/benchmarks/direct_solve.cpp:27:
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/result_of.hpp:489: error: ‘boost’ was not declared in this scope
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/result_of.hpp:489: error: template argument 1 is invalid
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/result_of.hpp:495: error: ‘boost’ was not declared in this scope
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/result_of.hpp:495: error: template argument 1 is invalid
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/result_of.hpp:501: error: ‘boost’ was not declared in this scope
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/result_of.hpp:501: error: template argument 1 is invalid
In file included from /scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/linalg/scalar_operations.hpp:29,
                 from /scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/scalar.hpp:30,
                 from /scr_ivy/dmeiser/ptsolveall/viennacl/examples/benchmarks/direct_solve.cpp:27:
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/traits/size.hpp:75: error: variable or field ‘resize’ declared void
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/traits/size.hpp:75: error: ‘boost’ has not been declared
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/traits/size.hpp:75: error: expected primary-expression before ‘>’ token
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/traits/size.hpp:75: error: missing template arguments before ‘,’ token
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/traits/size.hpp:76: error: expected primary-expression before ‘rows’
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/traits/size.hpp:77: error: expected primary-expression before ‘cols’
In file included from /scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/linalg/prod.hpp:30,
                 from /scr_ivy/dmeiser/ptsolveall/viennacl/examples/benchmarks/direct_solve.cpp:31:
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/tag_of.hpp:154: error: ‘boost’ was not declared in this scope
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/tag_of.hpp:154: error: template argument 1 is invalid
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/tag_of.hpp:160: error: ‘boost’ was not declared in this scope
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/tag_of.hpp:160: error: template argument 1 is invalid
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/tag_of.hpp:166: error: ‘boost’ was not declared in this scope
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/tag_of.hpp:166: error: template argument 1 is invalid
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/tag_of.hpp:172: error: ‘boost’ was not declared in this scope
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/meta/tag_of.hpp:172: error: template argument 1 is invalid
In file included from /scr_ivy/dmeiser/ptsolveall/viennacl/examples/benchmarks/direct_solve.cpp:31:
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/linalg/prod.hpp: In function ‘typename viennacl::enable_if<viennacl::is_ublas::value, VectorT>::type viennacl::linalg::prod(const MatrixT&, const VectorT&)’:
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/linalg/prod.hpp:79: error: ‘boost’ has not been declared
In file included from /scr_ivy/dmeiser/ptsolveall/viennacl/examples/benchmarks/direct_solve.cpp:32:
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/linalg/norm_2.hpp: In function ‘typename viennacl::enable_if<viennacl::is_ublas::value, typename VectorT::value_type>::type viennacl::linalg::norm_2(const VectorT&)’:
/scr_ivy/dmeiser/ptsolveall/viennacl/viennacl/linalg/norm_2.hpp:77: error: ‘boost’ has not been declared
```

I wasn't able to figure out whether the `direct_solve` benchmark should depend on ublas or not. This pull request moves `direct_solve` to the examples requiring ublas. Could be I'm doing something wrong.
