### PR TITLE
Add travis and coveralls support.

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-ci
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: cpp
+compiler:
+- gcc
+before_install:
+- sudo apt-get update -qq
+- sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-test1.48-dev libboost-system1.48-dev libboost-filesystem1.48-dev libboost-timer1.48-dev libboost-program-options1.48-dev libboost-thread1.48-dev python-yaml lcov libopencv-dev
+- gem install coveralls-lcov
+script:
+- mkdir -p build
+- cd build
+- cmake ..
+- make -j4
+- ./examples/tutorial/viennacl-info
+- ctest -j4 --output-on-failure
+after_success:
+- lcov -d test -base-directory .. -c -o coverage.info
+- lcov --remove coverage.info '/usr*' -o coverage.info
+- cd ..
+- coveralls-lcov build/coverage.info
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/d-meiser/viennacl-dev.svg?branch=master)](https://travis-ci.org/d-meiser/viennacl-dev)
+[![Coverage Status](https://img.shields.io/coveralls/d-meiser/viennacl-dev.svg)](https://coveralls.io/r/d-meiser/viennacl-dev)
 Developer Repository for ViennaCL
 ==========================================
 


### PR DESCRIPTION
I set up travis and coveralls for viennacl-dev. I did this to check if I could reproduce the test failure I reported in #105. But perhaps you're interested in incorporating these modifications upstream.

The basic idea is that an automatic build is fired off every time a change is pushed to github. This includes running the test suite. Test coverage data is collected as a side effect. An example of a test log is here:

https://travis-ci.org/d-meiser/viennacl-dev/builds/39989794

As you can see two tests are failing on the travis virtual machine. I have no idea why those tests are failing (they're passing on my local machine).
