### PR TITLE
Disable coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,4 @@ script:
 - make -j4
 - ./examples/tutorial/viennacl-info
 - ctest -j4 --output-on-failure
-after_success:
-- lcov -d test -base-directory .. -c -o coverage.info
-- lcov --remove coverage.info '/usr*' -o coverage.info
-- cd ..
-- coveralls-lcov build/coverage.info
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/viennacl/viennacl-dev.svg?branch=master)](https://travis-ci.org/viennacl/viennacl-dev)
-[![Coverage Status](https://img.shields.io/coveralls/viennacl/viennacl-dev.svg)](https://coveralls.io/r/viennacl/viennacl-dev)
 Developer Repository for ViennaCL
 ==========================================
 


### PR DESCRIPTION
lcov takes much too long making the travis builds time out and fail. Need to explore/discuss solutions.
