### PR TITLE
Cast result of &vector to Vector* before comparison in CG

### DIFF
--- a/viennacl/linalg/cg.hpp
+++ b/viennacl/linalg/cg.hpp
@@ -443,7 +443,7 @@ VectorT solve(MatrixT const & matrix, VectorT const & rhs, cg_tag const & tag, P
     z = residual;
     precond.apply(z);
 
-    if (&residual==&z)
+    if (static_cast<VectorT*>(&residual)==static_cast<VectorT*>(&z))
       new_ip_rr = std::pow(viennacl::linalg::norm_2(residual),2);
     else
       new_ip_rr = viennacl::linalg::inner_prod(residual, z);


### PR DESCRIPTION
Hi,

This PR solves a problem in CG solver which occurs when [using](https://github.com/ddemidov/vexcl/blob/master/examples/viennacl/solvers.cpp#L80-L84) the ViennaCL solver with VexCL types.

VexCL types provide an overload of `operator&` which returns an expression. The expression may be casted to the corresponding pointer, but applying `operator==` directly to the results of `operator&` yields yet another expression, which is not convertible to a bool. In other words, the line that is changed by this PR results in a compilation error.

I know the code is perfectly OK as it is, so I would understand if you reject the change. 