### PR TITLE
added eigen map size methods

### DIFF
--- a/viennacl/meta/result_of.hpp
+++ b/viennacl/meta/result_of.hpp
@@ -177,6 +177,12 @@ struct size_type< Eigen::Matrix<T, a, b, c, d, e> >
   typedef vcl_size_t   type;
 };
 
+template<class T, int a, int b, int c, int d, int e>
+struct size_type< Eigen::Map<Eigen::Matrix<T, a, b, c, d, e> > >
+{
+  typedef vcl_size_t   type;
+};
+
 template<>
 struct size_type<Eigen::VectorXf>
 {

--- a/viennacl/traits/size.hpp
+++ b/viennacl/traits/size.hpp
@@ -257,6 +257,8 @@ inline vcl_size_t size1(arma::SpMat<NumericT> const & A) { return A.n_rows; }
 #ifdef VIENNACL_WITH_EIGEN
 inline vcl_size_t size1(Eigen::MatrixXf const & m) { return static_cast<vcl_size_t>(m.rows()); }
 inline vcl_size_t size1(Eigen::MatrixXd const & m) { return static_cast<vcl_size_t>(m.rows()); }
+inline vcl_size_t size1(Eigen::Map<Eigen::MatrixXf> const & m) { return static_cast<vcl_size_t>(m.rows()); }
+inline vcl_size_t size1(Eigen::Map<Eigen::MatrixXd> const & m) { return static_cast<vcl_size_t>(m.rows()); }
 template<typename T, int options>
 inline vcl_size_t size1(Eigen::SparseMatrix<T, options> & m) { return static_cast<vcl_size_t>(m.rows()); }
 #endif
@@ -289,6 +291,8 @@ inline vcl_size_t size2(arma::SpMat<NumericT> const & A) { return A.n_cols; }
 #ifdef VIENNACL_WITH_EIGEN
 inline vcl_size_t size2(Eigen::MatrixXf const & m) { return m.cols(); }
 inline vcl_size_t size2(Eigen::MatrixXd const & m) { return m.cols(); }
+inline vcl_size_t size2(Eigen::Map<Eigen::MatrixXf> const & m) { return m.cols(); }
+inline vcl_size_t size2(Eigen::Map<Eigen::MatrixXd> const & m) { return m.cols(); }
 template<typename T, int options>
 inline vcl_size_t size2(Eigen::SparseMatrix<T, options> & m) { return m.cols(); }
 #endif


### PR DESCRIPTION
After working some more with the new Map Eigen classes #137 I occasionally have run in to the problem where I would get a compiler error that there was no method for 'size1' or 'size2'.  Not sure exactly why it was working sometimes as opposed to others but I looked in your code and noticed that such methods were in fact missing.  I added the following few small changes and tested that it fixed the error I was seeing.  Feel free to let me know if just adding methods like this is not encouraged.