### PR TITLE
allow for viennacl::vector object for eigenvalues

### DIFF
--- a/examples/tutorial/qr_method.cpp
+++ b/examples/tutorial/qr_method.cpp
@@ -89,6 +89,9 @@ int main()
   std::vector<ScalarType> eigenvalues_ref(9);
   std::vector<ScalarType> eigenvalues(9);
 
+  viennacl::vector<ScalarType> vcl_eigenvalues(9);
+  //copy(eigenvalues, vcl_eigenvalues);
+
   initialize(A_input, eigenvalues_ref);
 
   std::cout << std::endl <<"Input matrix: " << std::endl;
@@ -104,7 +107,10 @@ int main()
   **/
 
   std::cout << "Calculation..." << std::endl;
-  viennacl::linalg::qr_method_sym(A_input, Q, eigenvalues);
+  //viennacl::linalg::qr_method_sym(A_input, Q, eigenvalues);
+  viennacl::linalg::qr_method_sym(A_input, Q, vcl_eigenvalues);
+
+  copy(vcl_eigenvalues, eigenvalues);
 
   /**
   *   Print the computed eigenvalues and eigenvectors:

--- a/viennacl/linalg/qr-method.hpp
+++ b/viennacl/linalg/qr-method.hpp
@@ -689,6 +689,470 @@ void update_float_QR_column_gpu(matrix_base<SCALARTYPE> & A,
         V = viennacl::linalg::prod(trans(tmp), vcl_H);
     }
 
+    // Added by Charles Determan Jr. 07/17/2015
+    // Accept viennacl::vector instead of std::vector for eigenvalues
+    // Nonsymmetric reduction from Hessenberg to real Schur form.
+    // This is derived from the Algol procedure hqr2, by Martin and Wilkinson, Handbook for Auto. Comp.,
+    // Vol.ii-Linear Algebra, and the corresponding  Fortran subroutine in EISPACK.
+    template <typename SCALARTYPE, typename VectorType>
+    void hqr2(viennacl::matrix<SCALARTYPE>& vcl_H,
+                viennacl::matrix<SCALARTYPE>& V,
+                viennacl::vector<SCALARTYPE> & d,
+                VectorType & e)
+    {
+        transpose(V);
+
+        int nn = static_cast<int>(vcl_H.size1());
+
+        FastMatrix<SCALARTYPE> H(vcl_size_t(nn), vcl_H.internal_size2());//, V(nn);
+
+        std::vector<SCALARTYPE>  buf(5 * vcl_size_t(nn));
+        //boost::numeric::ublas::vector<float>  buf(5 * nn);
+        viennacl::vector<SCALARTYPE> buf_vcl(5 * vcl_size_t(nn));
+
+        viennacl::fast_copy(vcl_H, H.begin());
+
+
+        int n = nn - 1;
+
+        SCALARTYPE eps = 2 * static_cast<SCALARTYPE>(EPS);
+        SCALARTYPE exshift = 0;
+        SCALARTYPE p = 0;
+        SCALARTYPE q = 0;
+        SCALARTYPE r = 0;
+        SCALARTYPE s = 0;
+        SCALARTYPE z = 0;
+        SCALARTYPE t;
+        SCALARTYPE w;
+        SCALARTYPE x;
+        SCALARTYPE y;
+
+        SCALARTYPE out1, out2;
+
+        // compute matrix norm
+        SCALARTYPE norm = 0;
+        for (int i = 0; i < nn; i++)
+        {
+            for (int j = std::max(i - 1, 0); j < nn; j++)
+                norm = norm + std::fabs(H(i, j));
+        }
+
+        // Outer loop over eigenvalue index
+        int iter = 0;
+        while (n >= 0)
+        {
+            // Look for single small sub-diagonal element
+            int l = n;
+            while (l > 0)
+            {
+                s = std::fabs(H(l - 1, l - 1)) + std::fabs(H(l, l));
+                if (s <= 0)
+                  s = norm;
+                if (std::fabs(H(l, l - 1)) < eps * s)
+                  break;
+
+                l--;
+            }
+
+            // Check for convergence
+            if (l == n)
+            {
+                // One root found
+                H(n, n) = H(n, n) + exshift;
+                d[vcl_size_t(n)] = H(n, n);
+                e[vcl_size_t(n)] = 0;
+                n--;
+                iter = 0;
+            }
+            else if (l == n - 1)
+            {
+                // Two roots found
+                w = H(n, n - 1) * H(n - 1, n);
+                p = (H(n - 1, n - 1) - H(n, n)) / 2;
+                q = p * p + w;
+                z = static_cast<SCALARTYPE>(std::sqrt(std::fabs(q)));
+                H(n, n) = H(n, n) + exshift;
+                H(n - 1, n - 1) = H(n - 1, n - 1) + exshift;
+                x = H(n, n);
+
+                if (q >= 0)
+                {
+                    // Real pair
+                    z = (p >= 0) ? (p + z) : (p - z);
+                    d[vcl_size_t(n) - 1] = x + z;
+                    d[vcl_size_t(n)] = d[vcl_size_t(n) - 1];
+                    if (z <= 0 && z >= 0) // z == 0 without compiler complaints
+                      d[vcl_size_t(n)] = x - w / z;
+                    e[vcl_size_t(n) - 1] = 0;
+                    e[vcl_size_t(n)] = 0;
+                    x = H(n, n - 1);
+                    s = std::fabs(x) + std::fabs(z);
+                    p = x / s;
+                    q = z / s;
+                    r = static_cast<SCALARTYPE>(std::sqrt(p * p + q * q));
+                    p = p / r;
+                    q = q / r;
+
+                    // Row modification
+                    for (int j = n - 1; j < nn; j++)
+                    {
+                        SCALARTYPE h_nj = H(n, j);
+                        z = H(n - 1, j);
+                        H(n - 1, j) = q * z + p * h_nj;
+                        H(n, j) = q * h_nj - p * z;
+                    }
+
+                    final_iter_update(H, n, n + 1, q, p);
+                    final_iter_update_gpu(V, n, nn, q, p);
+                }
+                else
+                {
+                    // Complex pair
+                    d[vcl_size_t(n) - 1] = x + p;
+                    d[vcl_size_t(n)] = x + p;
+                    e[vcl_size_t(n) - 1] = z;
+                    e[vcl_size_t(n)] = -z;
+                }
+
+                n = n - 2;
+                iter = 0;
+            }
+            else
+            {
+                // No convergence yet
+
+                // Form shift
+                x = H(n, n);
+                y = 0;
+                w = 0;
+                if (l < n)
+                {
+                    y = H(n - 1, n - 1);
+                    w = H(n, n - 1) * H(n - 1, n);
+                }
+
+                // Wilkinson's original ad hoc shift
+                if (iter == 10)
+                {
+                    exshift += x;
+                    for (int i = 0; i <= n; i++)
+                        H(i, i) -= x;
+
+                    s = std::fabs(H(n, n - 1)) + std::fabs(H(n - 1, n - 2));
+                    x = y = SCALARTYPE(0.75) * s;
+                    w = SCALARTYPE(-0.4375) * s * s;
+                }
+
+                // MATLAB's new ad hoc shift
+                if (iter == 30)
+                {
+                    s = (y - x) / 2;
+                    s = s * s + w;
+                    if (s > 0)
+                    {
+                        s = static_cast<SCALARTYPE>(std::sqrt(s));
+                        if (y < x) s = -s;
+                        s = x - w / ((y - x) / 2 + s);
+                        for (int i = 0; i <= n; i++)
+                            H(i, i) -= s;
+                        exshift += s;
+                        x = y = w = SCALARTYPE(0.964);
+                    }
+                }
+
+                iter = iter + 1;
+
+                // Look for two consecutive small sub-diagonal elements
+                int m = n - 2;
+                while (m >= l)
+                {
+                    SCALARTYPE h_m1_m1 = H(m + 1, m + 1);
+                    z = H(m, m);
+                    r = x - z;
+                    s = y - z;
+                    p = (r * s - w) / H(m + 1, m) + H(m, m + 1);
+                    q = h_m1_m1 - z - r - s;
+                    r = H(m + 2, m + 1);
+                    s = std::fabs(p) + std::fabs(q) + std::fabs(r);
+                    p = p / s;
+                    q = q / s;
+                    r = r / s;
+                    if (m == l)
+                        break;
+                    if (std::fabs(H(m, m - 1)) * (std::fabs(q) + std::fabs(r)) < eps * (std::fabs(p) * (std::fabs(H(m - 1, m - 1)) + std::fabs(z) + std::fabs(h_m1_m1))))
+                        break;
+                    m--;
+                }
+
+                for (int i = m + 2; i <= n; i++)
+                {
+                    H(i, i - 2) = 0;
+                    if (i > m + 2)
+                        H(i, i - 3) = 0;
+                }
+
+                // float QR step involving rows l:n and columns m:n
+                for (int k = m; k < n; k++)
+                {
+                    bool notlast = (k != n - 1);
+                    if (k != m)
+                    {
+                        p = H(k, k - 1);
+                        q = H(k + 1, k - 1);
+                        r = (notlast ? H(k + 2, k - 1) : 0);
+                        x = std::fabs(p) + std::fabs(q) + std::fabs(r);
+                        if (x > 0)
+                        {
+                            p = p / x;
+                            q = q / x;
+                            r = r / x;
+                        }
+                    }
+
+                    if (x <= 0 && x >= 0) break;  // x == 0 without compiler complaints
+
+                    s = static_cast<SCALARTYPE>(std::sqrt(p * p + q * q + r * r));
+                    if (p < 0) s = -s;
+
+                    if (s < 0 || s > 0)
+                    {
+                        if (k != m)
+                            H(k, k - 1) = -s * x;
+                        else
+                            if (l != m)
+                                H(k, k - 1) = -H(k, k - 1);
+
+                        p = p + s;
+                        y = q / s;
+                        z = r / s;
+                        x = p / s;
+                        q = q / p;
+                        r = r / p;
+
+                        buf[5 * vcl_size_t(k)] = x;
+                        buf[5 * vcl_size_t(k) + 1] = y;
+                        buf[5 * vcl_size_t(k) + 2] = z;
+                        buf[5 * vcl_size_t(k) + 3] = q;
+                        buf[5 * vcl_size_t(k) + 4] = r;
+
+
+                        SCALARTYPE* a_row_k = H.row(k);
+                        SCALARTYPE* a_row_k_1 = H.row(k + 1);
+                        SCALARTYPE* a_row_k_2 = H.row(k + 2);
+                        // Row modification
+                        for (int j = k; j < nn; j++)
+                        {
+                            SCALARTYPE h_kj = a_row_k[j];
+                            SCALARTYPE h_k1_j = a_row_k_1[j];
+
+                            p = h_kj + q * h_k1_j;
+                            if (notlast)
+                            {
+                                SCALARTYPE h_k2_j = a_row_k_2[j];
+                                p = p + r * h_k2_j;
+                                a_row_k_2[j] = h_k2_j - p * z;
+                            }
+
+                            a_row_k[j] = h_kj - p * x;
+                            a_row_k_1[j] = h_k1_j - p * y;
+                        }
+
+                        //H(k + 1, nn - 1) = h_kj;
+
+
+                        // Column modification
+                        for (int i = k; i < std::min(nn, k + 4); i++)
+                        {
+                            p = x * H(i, k) + y * H(i, k + 1);
+                            if (notlast)
+                            {
+                                p = p + z * H(i, k + 2);
+                                H(i, k + 2) = H(i, k + 2) - p * r;
+                            }
+
+                            H(i, k) = H(i, k) - p;
+                            H(i, k + 1) = H(i, k + 1) - p * q;
+                        }
+                    }
+                    else
+                    {
+                        buf[5 * vcl_size_t(k)] = 0;
+                        buf[5 * vcl_size_t(k) + 1] = 0;
+                        buf[5 * vcl_size_t(k) + 2] = 0;
+                        buf[5 * vcl_size_t(k) + 3] = 0;
+                        buf[5 * vcl_size_t(k) + 4] = 0;
+                    }
+                }
+
+                // Timer timer;
+                // timer.start();
+
+                update_float_QR_column<SCALARTYPE>(H, buf, m, n, n, true);
+                update_float_QR_column_gpu(V, buf, buf_vcl, m, n, nn, false);
+
+                // std::cout << timer.get() << "\n";
+            }
+        }
+
+        // Backsubstitute to find vectors of upper triangular form
+        if (norm <= 0)
+        {
+            return;
+        }
+
+        for (n = nn - 1; n >= 0; n--)
+        {
+            p = d[vcl_size_t(n)];
+            q = e[vcl_size_t(n)];
+
+            // Real vector
+            if (q <= 0 && q >= 0)
+            {
+                int l = n;
+                H(n, n) = 1;
+                for (int i = n - 1; i >= 0; i--)
+                {
+                    w = H(i, i) - p;
+                    r = 0;
+                    for (int j = l; j <= n; j++)
+                        r = r + H(i, j) * H(j, n);
+
+                    if (e[vcl_size_t(i)] < 0)
+                    {
+                        z = w;
+                        s = r;
+                    }
+                    else
+                    {
+                        l = i;
+                        if (e[vcl_size_t(i)] <= 0) // e[i] == 0 with previous if
+                        {
+                            H(i, n) = (w > 0 || w < 0) ? (-r / w) : (-r / (eps * norm));
+                        }
+                        else
+                        {
+                            // Solve real equations
+                            x = H(i, i + 1);
+                            y = H(i + 1, i);
+                            q = (d[vcl_size_t(i)] - p) * (d[vcl_size_t(i)] - p) + e[vcl_size_t(i)] * e[vcl_size_t(i)];
+                            t = (x * s - z * r) / q;
+                            H(i, n) = t;
+                            H(i + 1, n) = (std::fabs(x) > std::fabs(z)) ? ((-r - w * t) / x) : ((-s - y * t) / z);
+                        }
+
+                        // Overflow control
+                        t = std::fabs(H(i, n));
+                        if ((eps * t) * t > 1)
+                            for (int j = i; j <= n; j++)
+                                H(j, n) /= t;
+                    }
+                }
+            }
+            else if (q < 0)
+            {
+                // Complex vector
+                int l = n - 1;
+
+                // Last vector component imaginary so matrix is triangular
+                if (std::fabs(H(n, n - 1)) > std::fabs(H(n - 1, n)))
+                {
+                    H(n - 1, n - 1) = q / H(n, n - 1);
+                    H(n - 1, n) = -(H(n, n) - p) / H(n, n - 1);
+                }
+                else
+                {
+                    cdiv<SCALARTYPE>(0, -H(n - 1, n), H(n - 1, n - 1) - p, q, out1, out2);
+
+                    H(n - 1, n - 1) = out1;
+                    H(n - 1, n) = out2;
+                }
+
+                H(n, n - 1) = 0;
+                H(n, n) = 1;
+                for (int i = n - 2; i >= 0; i--)
+                {
+                    SCALARTYPE ra, sa, vr, vi;
+                    ra = 0;
+                    sa = 0;
+                    for (int j = l; j <= n; j++)
+                    {
+                        SCALARTYPE h_ij = H(i, j);
+                        ra = ra + h_ij * H(j, n - 1);
+                        sa = sa + h_ij * H(j, n);
+                    }
+
+                    w = H(i, i) - p;
+
+                    if (e[vcl_size_t(i)] < 0)
+                    {
+                        z = w;
+                        r = ra;
+                        s = sa;
+                    }
+                    else
+                    {
+                        l = i;
+                        if (e[vcl_size_t(i)] <= 0) // e[i] == 0 with previous if
+                        {
+                            cdiv<SCALARTYPE>(-ra, -sa, w, q, out1, out2);
+                            H(i, n - 1) = out1;
+                            H(i, n) = out2;
+                        }
+                        else
+                        {
+                            // Solve complex equations
+                            x = H(i, i + 1);
+                            y = H(i + 1, i);
+                            vr = (d[vcl_size_t(i)] - p) * (d[vcl_size_t(i)] - p) + e[vcl_size_t(i)] * e[vcl_size_t(i)] - q * q;
+                            vi = (d[vcl_size_t(i)] - p) * 2 * q;
+                            if ( (vr <= 0 && vr >= 0) && (vi <= 0 && vi >= 0) )
+                                vr = eps * norm * (std::fabs(w) + std::fabs(q) + std::fabs(x) + std::fabs(y) + std::fabs(z));
+
+                            cdiv<SCALARTYPE>(x * r - z * ra + q * sa, x * s - z * sa - q * ra, vr, vi, out1, out2);
+
+                            H(i, n - 1) = out1;
+                            H(i, n) = out2;
+
+
+                            if (std::fabs(x) > (std::fabs(z) + std::fabs(q)))
+                            {
+                                H(i + 1, n - 1) = (-ra - w * H(i, n - 1) + q * H(i, n)) / x;
+                                H(i + 1, n) = (-sa - w * H(i, n) - q * H(i, n - 1)) / x;
+                            }
+                            else
+                            {
+                                cdiv<SCALARTYPE>(-r - y * H(i, n - 1), -s - y * H(i, n), z, q, out1, out2);
+
+                                H(i + 1, n - 1) = out1;
+                                H(i + 1, n) = out2;
+                            }
+                        }
+
+                        // Overflow control
+                        t = std::max(std::fabs(H(i, n - 1)), std::fabs(H(i, n)));
+                        if ((eps * t) * t > 1)
+                        {
+                            for (int j = i; j <= n; j++)
+                            {
+                                H(j, n - 1) /= t;
+                                H(j, n) /= t;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        viennacl::fast_copy(H.begin(), H.end(),  vcl_H);
+        // viennacl::fast_copy(V.begin(), V.end(),  vcl_V);
+
+        viennacl::matrix<SCALARTYPE> tmp = V;
+
+        V = viennacl::linalg::prod(trans(tmp), vcl_H);
+    }
+
+
+
 
     template <typename SCALARTYPE>
     bool householder_twoside(
@@ -790,6 +1254,83 @@ void update_float_QR_column_gpu(matrix_base<SCALARTYPE> & A,
 
         copy(eigen_values, A);
     }
+
+
+    // Added by Charles Determan Jr. 07/17/2015
+    // template for accepting a viennacl::vector instead of std::vector
+    // for the eigenvalues
+    template <typename SCALARTYPE>
+    void qr_method(viennacl::matrix<SCALARTYPE> & A,
+                   viennacl::matrix<SCALARTYPE> & Q,
+                   viennacl::vector<SCALARTYPE> & D,
+                   std::vector<SCALARTYPE> & E,
+                   bool is_symmetric = true)
+    {
+
+        assert(A.size1() == A.size2() && bool("Input matrix must be square for QR method!"));
+    /*    if (!viennacl::is_row_major<F>::value && !is_symmetric)
+        {
+          std::cout << "qr_method for non-symmetric column-major matrices not implemented yet!" << std::endl;
+          exit(EXIT_FAILURE);
+        }
+
+        */
+        vcl_size_t mat_size = A.size1();
+
+        if(A.size1() != D.size())
+	{
+	    throw "vector D length does not match matrix A rows";
+	}
+
+	E.resize(A.size1());
+
+
+        //viennacl::vector<SCALARTYPE> vcl_D(mat_size), vcl_E(mat_size);
+	viennacl::vector<SCALARTYPE> vcl_E(mat_size);
+        //std::vector<SCALARTYPE> std_D(mat_size), std_E(mat_size);
+
+        Q = viennacl::identity_matrix<SCALARTYPE>(Q.size1());
+
+        // reduce to tridiagonal form
+        detail::tridiagonal_reduction(A, Q);
+
+        // pack diagonal and super-diagonal
+        viennacl::linalg::bidiag_pack(A, D, vcl_E);
+	copy(vcl_E, E);
+
+        // find eigenvalues of symmetric tridiagonal matrix
+        if(is_symmetric)
+        {
+          viennacl::linalg::tql2(Q, D, E);
+
+        }
+        else
+        {
+              detail::hqr2(A, Q, D, E);
+        }
+
+
+        boost::numeric::ublas::matrix<float> eigen_values(A.size1(), A.size1());
+        eigen_values.clear();
+
+        for (vcl_size_t i = 0; i < A.size1(); i++)
+        {
+            if(std::fabs(E[i]) < EPS)
+            {
+                eigen_values(i, i) = D[i];
+            }
+            else
+            {
+                eigen_values(i, i) = D[i];
+                eigen_values(i, i + 1) = E[i];
+                eigen_values(i + 1, i) = -E[i];
+                eigen_values(i + 1, i + 1) = D[i];
+                i++;
+            }
+        }
+
+        copy(eigen_values, A);
+    }
 }
 
 template <typename SCALARTYPE>
@@ -806,6 +1347,17 @@ template <typename SCALARTYPE>
 void qr_method_sym(viennacl::matrix<SCALARTYPE>& A,
                    viennacl::matrix<SCALARTYPE>& Q,
                    std::vector<SCALARTYPE>& D
+                  )
+{
+    std::vector<SCALARTYPE> E(A.size1());
+
+    detail::qr_method(A, Q, D, E, true);
+}
+
+template <typename SCALARTYPE>
+void qr_method_sym(viennacl::matrix<SCALARTYPE>& A,
+                   viennacl::matrix<SCALARTYPE>& Q,
+                   viennacl::vector<SCALARTYPE>& D
                   )
 {
     std::vector<SCALARTYPE> E(A.size1());

--- a/viennacl/linalg/tql2.hpp
+++ b/viennacl/linalg/tql2.hpp
@@ -257,6 +257,143 @@ void tql2(matrix_base<SCALARTYPE, F> & Q,
 */
 
 }
+
+// Added by Charles Determan Jr. 07/17/2015
+// Accept a viennacl::vector instead of std::vector
+// Symmetric tridiagonal QL algorithm.
+// This is derived from the Algol procedures tql2, by Bowdler, Martin, Reinsch, and Wilkinson,
+// Handbook for Auto. Comp., Vol.ii-Linear Algebra, and the corresponding Fortran subroutine in EISPACK.
+template <typename SCALARTYPE, typename VectorType, typename F>
+void tql2(matrix_base<SCALARTYPE, F> & Q,
+          viennacl::vector<SCALARTYPE> & d,
+          VectorType & e)
+{
+    int n = static_cast<int>(viennacl::traits::size1(Q));
+
+    //boost::numeric::ublas::vector<SCALARTYPE> cs(n), ss(n);
+    std::vector<SCALARTYPE> cs(n), ss(n);
+    viennacl::vector<SCALARTYPE> tmp1(n), tmp2(n);
+
+    for (int i = 1; i < n; i++)
+        e[i - 1] = e[i];
+
+    e[n - 1] = 0;
+
+    SCALARTYPE f = 0;
+    SCALARTYPE tst1 = 0;
+    SCALARTYPE eps = static_cast<SCALARTYPE>(viennacl::linalg::detail::EPS);
+
+    for (int l = 0; l < n; l++)
+    {
+        // Find small subdiagonal element.
+        tst1 = std::max<SCALARTYPE>(tst1, std::fabs(d[l]) + std::fabs(e[l]));
+        int m = l;
+        while (m < n)
+        {
+            if (std::fabs(e[m]) <= eps * tst1)
+                break;
+            m++;
+        }
+
+        // If m == l, d[l) is an eigenvalue, otherwise, iterate.
+        if (m > l)
+        {
+            int iter = 0;
+            do
+            {
+                iter = iter + 1;  // (Could check iteration count here.)
+
+                // Compute implicit shift
+                SCALARTYPE g = d[l];
+                SCALARTYPE p = (d[l + 1] - g) / (2 * e[l]);
+                SCALARTYPE r = viennacl::linalg::detail::pythag<SCALARTYPE>(p, 1);
+                if (p < 0)
+                {
+                    r = -r;
+                }
+
+                d[l] = e[l] / (p + r);
+                d[l + 1] = e[l] * (p + r);
+                SCALARTYPE dl1 = d[l + 1];
+                SCALARTYPE h = g - d[l];
+                for (int i = l + 2; i < n; i++)
+                {
+                    d[i] -= h;
+                }
+
+                f = f + h;
+
+                // Implicit QL transformation.
+                p = d[m];
+                SCALARTYPE c = 1;
+                SCALARTYPE c2 = c;
+                SCALARTYPE c3 = c;
+                SCALARTYPE el1 = e[l + 1];
+                SCALARTYPE s = 0;
+                SCALARTYPE s2 = 0;
+                for (int i = m - 1; i >= l; i--)
+                {
+                    c3 = c2;
+                    c2 = c;
+                    s2 = s;
+                    g = c * e[i];
+                    h = c * p;
+                    r = viennacl::linalg::detail::pythag(p, e[i]);
+                    e[i + 1] = s * r;
+                    s = e[i] / r;
+                    c = p / r;
+                    p = c * d[i] - s * g;
+                    d[i + 1] = h + s * (c * g + s * d[i]);
+
+
+                    cs[i] = c;
+                    ss[i] = s;
+                }
+
+
+                p = -s * s2 * c3 * el1 * e[l] / dl1;
+                e[l] = s * p;
+                d[l] = c * p;
+
+                viennacl::copy(cs, tmp1);
+                viennacl::copy(ss, tmp2);
+
+                viennacl::linalg::givens_next(Q, tmp1, tmp2, l, m);
+
+                // Check for convergence.
+            }
+            while (std::fabs(e[l]) > eps * tst1);
+        }
+        d[l] = d[l] + f;
+        e[l] = 0;
+    }
+
+    // Sort eigenvalues and corresponding vectors.
+/*
+       for (int i = 0; i < n-1; i++) {
+          int k = i;
+          SCALARTYPE p = d[i];
+          for (int j = i+1; j < n; j++) {
+             if (d[j] > p) {
+                k = j;
+                p = d[j);
+             }
+          }
+          if (k != i) {
+             d[k] = d[i];
+             d[i] = p;
+             for (int j = 0; j < n; j++) {
+                p = Q(j, i);
+                Q(j, i) = Q(j, k);
+                Q(j, k) = p;
+             }
+          }
+       }
+
+*/
+
+}
+
 } // namespace linalg
 } // namespace viennacl
 #endif


### PR DESCRIPTION
After experimenting with the `qr_method` to get eigenvectors/eigenvalues I realized it wasn't possible to pass an existing `viennacl::vector` object to the method instead of the limited `std::vector`.  By passing the former, you allow more flexibility to copy the elements to any of the other library interfaces such as Armadillo, Eigen or the plain std objects with the `copy` command.  

To accomplish this I simply recreated some additional templates.  I also modified the example qr_method.cpp file to demonstrate how it works after I verified the the program compiles fine.

Let me know your thoughts if I have overlooked something that could potentially conflict with the backend or your library's format.  Naturally, feel free to omit my notes labeling my additions (which admittedly are mostly copies).  They were primarily for my own record keeping.