### PR TITLE
Typo fixes related to the Chow-Patel ILU

### DIFF
--- a/doc/manual/algorithms.dox
+++ b/doc/manual/algorithms.dox
@@ -203,8 +203,10 @@ std::cout << "Est. error: " << my_gmres_tag.error() << std::endl;
 
 \section manual-algorithms-preconditioners Preconditioners
 ViennaCL provides (partially) generic implementations of several preconditioners.
-The preconditioner setup is expect for simple diagonal preconditioners always carried out on the CPU host due to the need for dynamically allocating memory.
+Due to the need to dynamically allocate memory, preconditioner setup is usually carried out on the CPU host.
 Thus, one may not obtain an overall performance benefit if too much time is spent on the preconditioner setup.
+Exceptions are simple diagonal preconditioners and the Chow-Patel ILU and ICC preconditioners, which have static
+allocation patterns and can be computed on the backend device.
 
 \note Some preconditioners also work for Boost.uBLAS types!
 

--- a/examples/benchmarks/solver.cpp
+++ b/examples/benchmarks/solver.cpp
@@ -222,7 +222,7 @@ int run_benchmark(viennacl::context ctx)
   for (int runs=0; runs<BENCHMARK_RUNS; ++runs)
     vcl_chow_patel_icc.apply(vcl_vec1);
   viennacl::backend::finish();
-  std::cout << "ViennaCL Chow-Patel-ILU substitution time: " << timer.get() << std::endl;
+  std::cout << "ViennaCL Chow-Patel-ICC substitution time: " << timer.get() << std::endl;
 
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/viennacl/linalg/host_based/ilu_operations.hpp
+++ b/viennacl/linalg/host_based/ilu_operations.hpp
@@ -576,7 +576,7 @@ void ilu_chow_patel_sweep(compressed_matrix<NumericT>       & L,
       }
 
       // update l_ij:
-      assert(U_col_buffer[row_U_end - 1] == row && bool("Accessing U element which is not a diagonal element!"));
+      assert(U_col_buffer[row_U_end - 1] == col && bool("Accessing U element which is not a diagonal element!"));
       L_elements[j] = (aij_L_ptr[j] - sum) / U_backup[row_U_end - 1];  // diagonal element is last entry in U
     }
 


### PR DESCRIPTION
This includes one change which affects execution, namely fixing a bug
in an assertion in the host-based Chow-Patel code (recently fixed in another impl).

Also included are a couple of changes to docs and output
-Update to the manual note that some Preconditioners can be setup on the device
-Fix to some output in the benchmarks (ILU-->ICC)