### PR TITLE
Avoid incorrect flag when create ocl memory object.

### DIFF
--- a/viennacl/ocl/context.hpp
+++ b/viennacl/ocl/context.hpp
@@ -204,7 +204,7 @@ public:
 #if defined(VIENNACL_DEBUG_ALL) || defined(VIENNACL_DEBUG_CONTEXT)
     std::cout << "ViennaCL: Creating memory of size " << size << " for context " << h_ << " (unsafe, returning cl_mem directly)" << std::endl;
 #endif
-    if (ptr)
+    if (ptr && !(flags & CL_MEM_USE_HOST_PTR))
       flags |= CL_MEM_COPY_HOST_PTR;
     cl_int err;
     cl_mem mem = clCreateBuffer(h_.get(), flags, size, ptr, &err);


### PR DESCRIPTION
If there is already a CL_MEM_USE_HOST_PTR, we should not
add CL_MEM_COPY_HOST_PTR. According to the OpenCL spec:
"
CL_MEM_COPY_HOST_PTR and
CL_MEM_USE_HOST_PTR are mutually exclusive.
"

Signed-off-by: Zhigang Gong <zhigang.gong@intel.com>