### PR TITLE
should include Eigen/SparseCore instead of Eigen/Sparse

### DIFF
--- a/viennacl/meta/result_of.hpp
+++ b/viennacl/meta/result_of.hpp
@@ -39,7 +39,7 @@
 
 #ifdef VIENNACL_WITH_EIGEN
 #include <Eigen/Core>
-#include <Eigen/Sparse>
+#include <Eigen/SparseCore>
 #endif
 
 #ifdef VIENNACL_WITH_MTL4

--- a/viennacl/meta/tag_of.hpp
+++ b/viennacl/meta/tag_of.hpp
@@ -40,7 +40,7 @@
 
 #ifdef VIENNACL_WITH_EIGEN
 #include <Eigen/Core>
-#include <Eigen/Sparse>
+#include <Eigen/SparseCore>
 #endif
 
 #ifdef VIENNACL_WITH_MTL4

--- a/viennacl/traits/fill.hpp
+++ b/viennacl/traits/fill.hpp
@@ -30,7 +30,7 @@
 
 #ifdef VIENNACL_WITH_EIGEN
 #include <Eigen/Core>
-#include <Eigen/Sparse>
+#include <Eigen/SparseCore>
 #endif
 
 #include <vector>

--- a/viennacl/traits/size.hpp
+++ b/viennacl/traits/size.hpp
@@ -40,7 +40,7 @@
 
 #ifdef VIENNACL_WITH_EIGEN
 #include <Eigen/Core>
-#include <Eigen/Sparse>
+#include <Eigen/SparseCore>
 #endif
 
 #ifdef VIENNACL_WITH_MTL4


### PR DESCRIPTION
Eigen/Sparse includes some solver codes,  not only its sparse matrix core library. It does not seems to be needed to include Eigen/Sparse from ViennaCL.

https://eigen.tuxfamily.org/dox/group__TutorialSparse.html

And some  solver codes of the Eigen sparse matrix are licensed under LGPL. 
Hence when  EIGEN_MPL2_ONLY defined, compile errors occur.

I am writing Ruby binding for viennacl, an eigen_enable one, and I want not to include these LGPL codes if not needed. So I request this patch.

I hope this patch would help your development.
Thanks for your great works.

Regards.