### PR TITLE
Compile all kernels before caching program binary

### DIFF
--- a/viennacl/ocl/context.hpp
+++ b/viennacl/ocl/context.hpp
@@ -455,6 +455,26 @@ public:
     }
     VIENNACL_ERR_CHECK(err);
 
+
+    programs_.push_back(tools::shared_ptr<ocl::program>(new ocl::program(temp, *this, prog_name)));
+    viennacl::ocl::program & prog = *programs_.back();
+
+    //
+    // Extract kernels
+    //
+    cl_kernel kernels[1024];
+    cl_uint   num_kernels_in_prog;
+    err = clCreateKernelsInProgram(prog.handle().get(), 1024, kernels, &num_kernels_in_prog);
+    VIENNACL_ERR_CHECK(err);
+
+    for (cl_uint i=0; i<num_kernels_in_prog; ++i)
+    {
+      char kernel_name[128];
+      err = clGetKernelInfo(kernels[i], CL_KERNEL_FUNCTION_NAME, 128, kernel_name, NULL);
+      prog.add_kernel(kernels[i], std::string(kernel_name));
+    }
+
+
     //
     // Store the program in the cache
     //
@@ -486,26 +506,6 @@ public:
         delete[] binaries[i];
 
       VIENNACL_ERR_CHECK(err);
-    }
-
-
-    programs_.push_back(tools::shared_ptr<ocl::program>(new ocl::program(temp, *this, prog_name)));
-
-    viennacl::ocl::program & prog = *programs_.back();
-
-    //
-    // Extract kernels
-    //
-    cl_kernel kernels[1024];
-    cl_uint   num_kernels_in_prog;
-    err = clCreateKernelsInProgram(prog.handle().get(), 1024, kernels, &num_kernels_in_prog);
-    VIENNACL_ERR_CHECK(err);
-
-    for (cl_uint i=0; i<num_kernels_in_prog; ++i)
-    {
-      char kernel_name[128];
-      err = clGetKernelInfo(kernels[i], CL_KERNEL_FUNCTION_NAME, 128, kernel_name, NULL);
-      prog.add_kernel(kernels[i], std::string(kernel_name));
     }
 
 #if defined(VIENNACL_DEBUG_ALL) || defined(VIENNACL_DEBUG_CONTEXT)


### PR DESCRIPTION
This PR proposes a new caching mechanism for OpenCL binaries.

The current mechanism caches the program binary after the `clBuildProgram()` call but before the `clCreateKernelsInProgram()` call. The proposed mechanism caches the program binary after both the `clBuildProgram()` and `clCreateKernelsInProgram()` calls. 

This simple change has a dramatic effect on ARM Mali powered platforms, for example, it reduces the OpenCL Caffe initialisation time by over 50 times on subsequent invocations as measured on the Mali-T628 powered Odroid-XU3 board. At the same time, both the original and proposed mechanisms perform very similarly on NVIDIA GPU powered platforms.

The reason is that ARM's OpenCL implementation only compiles kernels when the user invokes `clCreateKernel()` or `clCreateKernelsInProgram()` (to avoid compiling all the kernels when only a few may potentially be needed), while NVIDIA's OpenCL implementation compiles all the kernels when the user invokes `clBuildProgram()`.

On the Odroid-XU3 platform, I conducted three experiments:
- `cache-none`: `VIENNACL_CACHE_PATH` is not defined;
- `cache-cold`: `VIENNACL_CACHE_PATH` is defined but does not contain any binaries;
- `cache-warm`: `VIENNACL_CACHE_PATH` is defined but contains binaries from a previous invocation.

With the original mechanism, all the three experiments result in very similar execution time:

![Original mechanism](https://cloud.githubusercontent.com/assets/6597818/23344516/c90ae280-fc75-11e6-9fc1-d2424efc10a6.png)

With the proposed mechanism, the execution time of all `clCreateKernelsinProgram()` calls is reduced by over 50 times in the `cache-warm` compared to the `cache-none` and `cache-cold` ones.
  
![Proposed mechanism](https://cloud.githubusercontent.com/assets/6597818/23344517/c9233a9c-fc75-11e6-96bf-fecbe9097ee3.png)

For more information (including experiments on the GTX 1080), please see this [Jupyter Notebook](https://nbviewer.jupyter.org/urls/dl.dropbox.com/s/sbqh8j9k2okprhp/ck-caffe-explore-opencl-build-compile-time.ipynb).