### PR TITLE
Include build options into cache hash and avoid overwriting cache

### DIFF
--- a/viennacl/ocl/context.hpp
+++ b/viennacl/ocl/context.hpp
@@ -410,12 +410,12 @@ public:
       std::string sha1 = tools::sha1(prefix + source + build_options_);
 
       std::ifstream cached((cache_path_+sha1).c_str(),std::ios::binary);
-      is_cached = (cached != NULL);
-      if (is_cached)
+      if (cached)
       {
+        is_cached = true;
+
         vcl_size_t len;
         std::vector<unsigned char> buffer;
-
         cached.read((char*)&len, sizeof(vcl_size_t));
         buffer.resize(len);
         cached.read((char*)(&buffer[0]), std::streamsize(len));

--- a/viennacl/ocl/context.hpp
+++ b/viennacl/ocl/context.hpp
@@ -395,8 +395,9 @@ public:
     cl_program temp = 0;
 
     //
-    // Retrieves the program in the cache
+    // Retrieve the program from the cache if it is already there
     //
+    bool is_cached = false;
     if (cache_path_.size())
     {
 #if defined(VIENNACL_DEBUG_ALL) || defined(VIENNACL_DEBUG_CONTEXT)
@@ -409,7 +410,8 @@ public:
       std::string sha1 = tools::sha1(prefix + source + build_options_);
 
       std::ifstream cached((cache_path_+sha1).c_str(),std::ios::binary);
-      if (cached)
+      is_cached = (cached != NULL);
+      if (is_cached)
       {
         vcl_size_t len;
         std::vector<unsigned char> buffer;
@@ -476,9 +478,9 @@ public:
 
 
     //
-    // Store the program in the cache
+    // Store the program into the cache if it is not already there
     //
-    if (cache_path_.size())
+    if (cache_path_.size() && !is_cached)
     {
       vcl_size_t len;
 

--- a/viennacl/ocl/context.hpp
+++ b/viennacl/ocl/context.hpp
@@ -406,7 +406,7 @@ public:
       std::string prefix;
       for(std::vector< viennacl::ocl::device >::const_iterator it = devices_.begin(); it != devices_.end(); ++it)
         prefix += it->name() + it->vendor() + it->driver_version();
-      std::string sha1 = tools::sha1(prefix + source);
+      std::string sha1 = tools::sha1(prefix + source + build_options_);
 
       std::ifstream cached((cache_path_+sha1).c_str(),std::ios::binary);
       if (cached)
@@ -496,7 +496,7 @@ public:
       std::string prefix;
       for(std::vector< viennacl::ocl::device >::const_iterator it = devices_.begin(); it != devices_.end(); ++it)
         prefix += it->name() + it->vendor() + it->driver_version();
-      std::string sha1 = tools::sha1(prefix + source);
+      std::string sha1 = tools::sha1(prefix + source + build_options_);
       std::ofstream cached((cache_path_+sha1).c_str(),std::ios::binary);
 
       cached.write((char*)&sizes[0], sizeof(vcl_size_t));


### PR DESCRIPTION
This PR introduces two changes:

1. When constructing the hash value for the program binary lookup, the string to be hashed must include the program build options. I've seen cases when the same program is compiled using different build options e.g. `-D FP_PRECISION=32` and `-D FP_PRECISION=64`.

2. Even when the program binary is already in the cache, it still gets written back to the filesystem. In my experiments with Caffe on several development boards, the execution time of the `add_program` method goes down from about 18 ms to about 12 ms with this change.