### PR TITLE
Add missing directive

### DIFF
--- a/libviennacl/src/blas2_opencl.cpp
+++ b/libviennacl/src/blas2_opencl.cpp
@@ -30,6 +30,7 @@
 #include "viennacl/linalg/direct_solve.hpp"
 #include "viennacl/linalg/prod.hpp"
 
+#ifdef VIENNACL_WITH_OPENCL
 
 // xGEMV
 
@@ -216,4 +217,4 @@ VIENNACL_EXPORTED_FUNCTION ViennaCLStatus ViennaCLOpenCLDger(ViennaCLBackend bac
 
   return ViennaCLSuccess;
 }
-
+#endif


### PR DESCRIPTION
Adds missing a preprocessor directive VIENNACL_WITH_OPENCL in blas2_opencl.cpp. This solves a compiling issue on the Windows operating system.